### PR TITLE
feat: add configurable transfer controls to disable token operations

### DIFF
--- a/examples/eliza/bun.lock
+++ b/examples/eliza/bun.lock
@@ -976,7 +976,7 @@
 
     "@elizaos/plugin-local-ai": ["@elizaos/plugin-local-ai@1.0.4", "", { "dependencies": { "@elizaos/core": "^1.0.0", "@huggingface/transformers": "^3.5.1", "node-llama-cpp": "3.8.1", "nodejs-whisper": "0.2.9", "stream-browserify": "^3.0.0", "tsup": "8.5.0", "undici": "^7.10.0", "uuid": "11.1.0", "whisper-node": "^1.1.1", "zod": "3.25.23" } }, "sha512-flBgh/v7MBCn2kXhkkMsHbzILMtHBEabwaS9a+Fh5CXMVD3u6+aePRg68GXY9aLRGxAENW+4wt5UP51v861Dmg=="],
 
-    "@elizaos/plugin-openai": ["@elizaos/plugin-openai@1.0.3", "", { "dependencies": { "@ai-sdk/openai": "^1.3.20", "@elizaos/core": "^1.0.0", "ai": "^4.3.16", "js-tiktoken": "^1.0.18", "tsup": "8.5.0", "undici": "^7.10.0" } }, "sha512-Ish3MM/KivXojLVvvBT4tG7Jrr1VFkCnj6NyrqQKMTbXeamSmtpp5ds4nTVQuxAWCvsqeU9oT776j3GBVNJeWA=="],
+    "@elizaos/plugin-openai": ["@elizaos/plugin-openai@1.0.4", "", { "dependencies": { "@ai-sdk/openai": "^1.3.20", "@elizaos/core": "^1.0.0", "ai": "^4.3.16", "js-tiktoken": "^1.0.18", "tsup": "8.5.0", "undici": "^7.10.0" } }, "sha512-hp+mQG0DxkyG/GZVR7KxTjiNMM0fB1WrlCcyQ2/fVhuqlf3PUWw7dlMiz8prj0JVksKiL90yeTC7+44mNMxXog=="],
 
     "@elizaos/plugin-sql": ["@elizaos/plugin-sql@workspace:packages/plugin-sql"],
 
@@ -7784,6 +7784,10 @@
 
     "@elizaos/autodoc/tsup/rollup": ["rollup@4.42.0", "", { "dependencies": { "@types/estree": "1.0.7" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.42.0", "@rollup/rollup-android-arm64": "4.42.0", "@rollup/rollup-darwin-arm64": "4.42.0", "@rollup/rollup-darwin-x64": "4.42.0", "@rollup/rollup-freebsd-arm64": "4.42.0", "@rollup/rollup-freebsd-x64": "4.42.0", "@rollup/rollup-linux-arm-gnueabihf": "4.42.0", "@rollup/rollup-linux-arm-musleabihf": "4.42.0", "@rollup/rollup-linux-arm64-gnu": "4.42.0", "@rollup/rollup-linux-arm64-musl": "4.42.0", "@rollup/rollup-linux-loongarch64-gnu": "4.42.0", "@rollup/rollup-linux-powerpc64le-gnu": "4.42.0", "@rollup/rollup-linux-riscv64-gnu": "4.42.0", "@rollup/rollup-linux-riscv64-musl": "4.42.0", "@rollup/rollup-linux-s390x-gnu": "4.42.0", "@rollup/rollup-linux-x64-gnu": "4.42.0", "@rollup/rollup-linux-x64-musl": "4.42.0", "@rollup/rollup-win32-arm64-msvc": "4.42.0", "@rollup/rollup-win32-ia32-msvc": "4.42.0", "@rollup/rollup-win32-x64-msvc": "4.42.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-LW+Vse3BJPyGJGAJt1j8pWDKPd73QM8cRXYK1IxOBgL2AGLu7Xd2YOW0M2sLUBCkF5MshXXtMApyEAEzMVMsnw=="],
 
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.34.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.34.0", "@typescript-eslint/type-utils": "8.34.0", "@typescript-eslint/utils": "8.34.0", "@typescript-eslint/visitor-keys": "8.34.0", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.34.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/parser": ["@typescript-eslint/parser@8.34.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.34.0", "@typescript-eslint/types": "8.34.0", "@typescript-eslint/typescript-estree": "8.34.0", "@typescript-eslint/visitor-keys": "8.34.0", "debug": "^4.3.4" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA=="],
+
     "@elizaos/cli/@swig-wallet/plugin-elizaos/tsup": ["tsup@8.5.0", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.25.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "0.8.0-beta.0", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ=="],
 
     "@elizaos/cli/@swig-wallet/plugin-elizaos/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
@@ -9002,6 +9006,22 @@
 
     "@elizaos/autodoc/tsup/rollup/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.34.0", "", { "dependencies": { "@typescript-eslint/types": "8.34.0", "@typescript-eslint/visitor-keys": "8.34.0" } }, "sha512-9Ac0X8WiLykl0aj1oYQNcLZjHgBojT6cW68yAgZ19letYu+Hxd0rE0veI1XznSSst1X5lwnxhPbVdwjDRIomRw=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.34.0", "", { "dependencies": { "@typescript-eslint/typescript-estree": "8.34.0", "@typescript-eslint/utils": "8.34.0", "debug": "^4.3.4", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-n7zSmOcUVhcRYC75W2pnPpbO1iwhJY3NLoHEtbJwJSNlVAZuwqu05zY3f3s2SDWWDSo9FdN5szqc73DCtDObAg=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/utils": ["@typescript-eslint/utils@8.34.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.34.0", "@typescript-eslint/types": "8.34.0", "@typescript-eslint/typescript-estree": "8.34.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-8L4tWatGchV9A1cKbjaavS6mwYwp39jql8xUmIIKJdm+qiaeHy5KMKlBrf30akXAWBzn2SqKsNOtSENWUwg7XQ=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.34.0", "", { "dependencies": { "@typescript-eslint/types": "8.34.0", "eslint-visitor-keys": "^4.2.0" } }, "sha512-qHV7pW7E85A0x6qyrFn+O+q1k1p3tQCsqIZ1KZ5ESLXY57aTvUd3/a4rdPTeXisvhXn2VQG0VSKUqs8KHF2zcA=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/parser/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.34.0", "", { "dependencies": { "@typescript-eslint/types": "8.34.0", "@typescript-eslint/visitor-keys": "8.34.0" } }, "sha512-9Ac0X8WiLykl0aj1oYQNcLZjHgBojT6cW68yAgZ19letYu+Hxd0rE0veI1XznSSst1X5lwnxhPbVdwjDRIomRw=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/parser/@typescript-eslint/types": ["@typescript-eslint/types@8.34.0", "", {}, "sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/parser/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.34.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.34.0", "@typescript-eslint/tsconfig-utils": "8.34.0", "@typescript-eslint/types": "8.34.0", "@typescript-eslint/visitor-keys": "8.34.0", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/parser/@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.34.0", "", { "dependencies": { "@typescript-eslint/types": "8.34.0", "eslint-visitor-keys": "^4.2.0" } }, "sha512-qHV7pW7E85A0x6qyrFn+O+q1k1p3tQCsqIZ1KZ5ESLXY57aTvUd3/a4rdPTeXisvhXn2VQG0VSKUqs8KHF2zcA=="],
+
     "@elizaos/cli/@swig-wallet/plugin-elizaos/tsup/rollup": ["rollup@4.42.0", "", { "dependencies": { "@types/estree": "1.0.7" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.42.0", "@rollup/rollup-android-arm64": "4.42.0", "@rollup/rollup-darwin-arm64": "4.42.0", "@rollup/rollup-darwin-x64": "4.42.0", "@rollup/rollup-freebsd-arm64": "4.42.0", "@rollup/rollup-freebsd-x64": "4.42.0", "@rollup/rollup-linux-arm-gnueabihf": "4.42.0", "@rollup/rollup-linux-arm-musleabihf": "4.42.0", "@rollup/rollup-linux-arm64-gnu": "4.42.0", "@rollup/rollup-linux-arm64-musl": "4.42.0", "@rollup/rollup-linux-loongarch64-gnu": "4.42.0", "@rollup/rollup-linux-powerpc64le-gnu": "4.42.0", "@rollup/rollup-linux-riscv64-gnu": "4.42.0", "@rollup/rollup-linux-riscv64-musl": "4.42.0", "@rollup/rollup-linux-s390x-gnu": "4.42.0", "@rollup/rollup-linux-x64-gnu": "4.42.0", "@rollup/rollup-linux-x64-musl": "4.42.0", "@rollup/rollup-win32-arm64-msvc": "4.42.0", "@rollup/rollup-win32-ia32-msvc": "4.42.0", "@rollup/rollup-win32-x64-msvc": "4.42.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-LW+Vse3BJPyGJGAJt1j8pWDKPd73QM8cRXYK1IxOBgL2AGLu7Xd2YOW0M2sLUBCkF5MshXXtMApyEAEzMVMsnw=="],
 
     "@elizaos/cli/tsup/rollup/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
@@ -9610,6 +9630,18 @@
 
     "@docusaurus/theme-classic/react-router-dom/react-router/path-to-regexp/isarray": ["isarray@0.0.1", "", {}, "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="],
 
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.34.0", "", {}, "sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.34.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.34.0", "@typescript-eslint/tsconfig-utils": "8.34.0", "@typescript-eslint/types": "8.34.0", "@typescript-eslint/visitor-keys": "8.34.0", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/types": ["@typescript-eslint/types@8.34.0", "", {}, "sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.34.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.34.0", "@typescript-eslint/tsconfig-utils": "8.34.0", "@typescript-eslint/types": "8.34.0", "@typescript-eslint/visitor-keys": "8.34.0", "debug": "^4.3.4", "fast-glob": "^3.3.2", "is-glob": "^4.0.3", "minimatch": "^9.0.4", "semver": "^7.6.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "typescript": ">=4.8.4 <5.9.0" } }, "sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/visitor-keys/@typescript-eslint/types": ["@typescript-eslint/types@8.34.0", "", {}, "sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/parser/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
     "@elizaos/cli/@swig-wallet/plugin-elizaos/tsup/rollup/@types/estree": ["@types/estree@1.0.7", "", {}, "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ=="],
 
     "@elizaos/plugin-0g/@elizaos/core/@ai-sdk/openai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.2", "", {}, "sha512-6RxOBZ/cYgd8usLwsEl+EC09Au/9BcmCKYF2/xbml6DNczf7nv0MQb+7BA2F+li6//I+28VNlQR37XfQtcAJuA=="],
@@ -9800,6 +9832,14 @@
 
     "@docusaurus/mdx-loader/remark-gfm/micromark-extension-gfm/micromark-util-combine-extensions/micromark-util-chunked/micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/@typescript-eslint/types": ["@typescript-eslint/types@8.34.0", "", {}, "sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/parser/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
     "@elizaos/plugin-0g/@elizaos/core/openai/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "@elizaos/plugin-0g/@elizaos/core/openai/node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
@@ -9825,6 +9865,10 @@
     "pkg-up/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "typescript-eslint/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "@elizaos/cli/@swig-wallet/plugin-elizaos/@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
     "@lerna/create/@octokit/rest/@octokit/core/@octokit/request/node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 

--- a/packages/plugin/README.md
+++ b/packages/plugin/README.md
@@ -39,14 +39,38 @@ Set these environment variables or add them to your character's settings:
 - `SOLANA_PRIVATE_KEY`: Your Solana wallet private key (as JSON array or base58 string)
 - `SOLANA_RPC_URL`: Solana RPC endpoint (optional, defaults to mainnet)
 
+### Optional Settings
+
+Configure plugin behavior with these optional settings:
+
+- `SWIG_TRANSFERS_ENABLED`: Enable/disable all transfer functionality (default: `true`)
+
+#### Transfer Control
+
+You can disable all transfer functionality by setting:
+
+```bash
+SWIG_TRANSFERS_ENABLED=false
+```
+
+When transfers are disabled, the agent will only have access to:
+
+- Creating Swig wallets
+- Checking Swig wallet balances (SOL and SPL tokens)
+- Viewing Swig wallet authorities
+- Querying wallet information
+
+Transfer actions (sending SOL/tokens to/from Swig wallets) will not be available.
+
 #### Environment Variables
 
 ```bash
-# base58 format
+# Required
 SOLANA_PRIVATE_KEY='your_base58_private_key'
 
-# RPC URL (optional)
+# Optional
 SOLANA_RPC_URL='https://api.mainnet-beta.solana.com'
+SWIG_TRANSFERS_ENABLED='true'  # Set to 'false' to disable transfers
 ```
 
 #### Character Settings
@@ -58,7 +82,8 @@ SOLANA_RPC_URL='https://api.mainnet-beta.solana.com'
   "settings": {
     "secrets": {
       "SOLANA_PRIVATE_KEY": "abc123...",
-      "SOLANA_RPC_URL": "https://api.mainnet-beta.solana.com"
+      "SOLANA_RPC_URL": "https://api.mainnet-beta.solana.com",
+      "SWIG_TRANSFERS_ENABLED": "true"
     }
   }
 }

--- a/packages/plugin/src/actions/swigTransferToAuthority.ts
+++ b/packages/plugin/src/actions/swigTransferToAuthority.ts
@@ -72,8 +72,8 @@ export const swigTransferToAuthorityAction: Action = {
   handler: async (
     runtime: IAgentRuntime,
     message: Memory,
-    state?: State,
-    options?: any,
+    _state?: State,
+    _options?: any,
     callback?: HandlerCallback,
     responses?: Memory[]
   ): Promise<boolean> => {
@@ -81,6 +81,31 @@ export const swigTransferToAuthorityAction: Action = {
     console.log('🔧 Callback function present:', !!callback);
     console.log('🔧 Message content:', message.content.text);
     console.log('🔧 Responses array length:', responses?.length || 0);
+
+    // Check if transfers are enabled
+    const transfersEnabledSetting = runtime.getSetting('SWIG_TRANSFERS_ENABLED');
+    const transfersEnabled =
+      transfersEnabledSetting === undefined ? true : String(transfersEnabledSetting) === 'true';
+
+    if (!transfersEnabled) {
+      console.log('🔧 Transfer operation blocked - transfers are disabled');
+      const errorContent = {
+        text: `❌ Transfer operations are currently disabled. Set SWIG_TRANSFERS_ENABLED=true to enable transfers.`,
+        thought: 'Transfer operations have been disabled in the plugin configuration.',
+        actions: ['SWIG_TRANSFER_TO_AUTHORITY', 'REPLY'],
+        source: message.content.source,
+      };
+
+      if (responses && responses.length > 0) {
+        responses[0].content = errorContent;
+      }
+
+      if (callback) {
+        await callback(errorContent);
+      }
+
+      return true;
+    }
 
     try {
       console.log('🔧 Step 1: Getting Solana wallet...');
@@ -230,7 +255,9 @@ export const swigTransferToAuthorityAction: Action = {
       console.error('🔧 Error stack:', error instanceof Error ? error.stack : 'No stack trace');
 
       const errorContent = {
-        text: `❌ Failed to transfer from Swig wallet to authority: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        text: `❌ Failed to transfer from Swig wallet to authority: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
         thought:
           'The transfer from Swig wallet to authority failed. This could be due to insufficient funds, invalid authority, insufficient permissions, or network issues.',
         actions: ['SWIG_TRANSFER_TO_AUTHORITY', 'REPLY'],

--- a/packages/plugin/src/actions/swigTransferTokenToAddress.ts
+++ b/packages/plugin/src/actions/swigTransferTokenToAddress.ts
@@ -94,8 +94,8 @@ export const swigTransferTokenToAddressAction: Action = {
   handler: async (
     runtime: IAgentRuntime,
     message: Memory,
-    state?: State,
-    options?: any,
+    _state?: State,
+    _options?: any,
     callback?: HandlerCallback,
     responses?: Memory[]
   ): Promise<boolean> => {
@@ -103,6 +103,31 @@ export const swigTransferTokenToAddressAction: Action = {
     console.log('🔧 Callback function present:', !!callback);
     console.log('🔧 Message content:', message.content.text);
     console.log('🔧 Responses array length:', responses?.length || 0);
+
+    // Check if transfers are enabled
+    const transfersEnabledSetting = runtime.getSetting('SWIG_TRANSFERS_ENABLED');
+    const transfersEnabled =
+      transfersEnabledSetting === undefined ? true : String(transfersEnabledSetting) === 'true';
+
+    if (!transfersEnabled) {
+      console.log('🔧 Transfer operation blocked - transfers are disabled');
+      const errorContent = {
+        text: `❌ Transfer operations are currently disabled. Set SWIG_TRANSFERS_ENABLED=true to enable transfers.`,
+        thought: 'Transfer operations have been disabled in the plugin configuration.',
+        actions: ['SWIG_TRANSFER_TOKEN_TO_ADDRESS', 'REPLY'],
+        source: message.content.source,
+      };
+
+      if (responses && responses.length > 0) {
+        responses[0].content = errorContent;
+      }
+
+      if (callback) {
+        await callback(errorContent);
+      }
+
+      return true;
+    }
 
     try {
       console.log('🔧 Step 1: Getting Solana wallet...');
@@ -282,7 +307,9 @@ export const swigTransferTokenToAddressAction: Action = {
       console.error('🔧 Error stack:', error instanceof Error ? error.stack : 'No stack trace');
 
       const errorContent = {
-        text: `❌ Failed to transfer token from Swig wallet: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        text: `❌ Failed to transfer token from Swig wallet: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
         thought:
           'The token transfer from Swig wallet failed. This could be due to insufficient token balance, insufficient authority permissions, network issues, or invalid parameters.',
         actions: ['SWIG_TRANSFER_TOKEN_TO_ADDRESS', 'REPLY'],

--- a/packages/plugin/src/actions/swigTransferTokenToAuthority.ts
+++ b/packages/plugin/src/actions/swigTransferTokenToAuthority.ts
@@ -88,8 +88,8 @@ export const swigTransferTokenToAuthorityAction: Action = {
   handler: async (
     runtime: IAgentRuntime,
     message: Memory,
-    state?: State,
-    options?: any,
+    _state?: State,
+    _options?: any,
     callback?: HandlerCallback,
     responses?: Memory[]
   ): Promise<boolean> => {
@@ -97,6 +97,31 @@ export const swigTransferTokenToAuthorityAction: Action = {
     console.log('🔧 Callback function present:', !!callback);
     console.log('🔧 Message content:', message.content.text);
     console.log('🔧 Responses array length:', responses?.length || 0);
+
+    // Check if transfers are enabled
+    const transfersEnabledSetting = runtime.getSetting('SWIG_TRANSFERS_ENABLED');
+    const transfersEnabled =
+      transfersEnabledSetting === undefined ? true : String(transfersEnabledSetting) === 'true';
+
+    if (!transfersEnabled) {
+      console.log('🔧 Transfer operation blocked - transfers are disabled');
+      const errorContent = {
+        text: `❌ Transfer operations are currently disabled. Set SWIG_TRANSFERS_ENABLED=true to enable transfers.`,
+        thought: 'Transfer operations have been disabled in the plugin configuration.',
+        actions: ['SWIG_TRANSFER_TOKEN_TO_AUTHORITY', 'REPLY'],
+        source: message.content.source,
+      };
+
+      if (responses && responses.length > 0) {
+        responses[0].content = errorContent;
+      }
+
+      if (callback) {
+        await callback(errorContent);
+      }
+
+      return true;
+    }
 
     try {
       console.log('🔧 Step 1: Getting Solana wallet...');
@@ -299,7 +324,9 @@ export const swigTransferTokenToAuthorityAction: Action = {
       console.error('🔧 Error stack:', error instanceof Error ? error.stack : 'No stack trace');
 
       const errorContent = {
-        text: `❌ Failed to transfer token from Swig wallet to authority: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        text: `❌ Failed to transfer token from Swig wallet to authority: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
         thought:
           'The token transfer from Swig wallet to authority failed. This could be due to insufficient token balance, invalid authority, insufficient permissions, or network issues.',
         actions: ['SWIG_TRANSFER_TOKEN_TO_AUTHORITY', 'REPLY'],

--- a/packages/plugin/src/actions/transferToSwig.ts
+++ b/packages/plugin/src/actions/transferToSwig.ts
@@ -72,8 +72,8 @@ export const transferToSwigAction: Action = {
   handler: async (
     runtime: IAgentRuntime,
     message: Memory,
-    state?: State,
-    options?: any,
+    _state?: State,
+    _options?: any,
     callback?: HandlerCallback,
     responses?: Memory[]
   ): Promise<boolean> => {
@@ -81,6 +81,31 @@ export const transferToSwigAction: Action = {
     console.log('🔧 Callback function present:', !!callback);
     console.log('🔧 Message content:', message.content.text);
     console.log('🔧 Responses array length:', responses?.length || 0);
+
+    // Check if transfers are enabled
+    const transfersEnabledSetting = runtime.getSetting('SWIG_TRANSFERS_ENABLED');
+    const transfersEnabled =
+      transfersEnabledSetting === undefined ? true : String(transfersEnabledSetting) === 'true';
+
+    if (!transfersEnabled) {
+      console.log('🔧 Transfer operation blocked - transfers are disabled');
+      const errorContent = {
+        text: `❌ Transfer operations are currently disabled. Set SWIG_TRANSFERS_ENABLED=true to enable transfers.`,
+        thought: 'Transfer operations have been disabled in the plugin configuration.',
+        actions: ['TRANSFER_TO_SWIG', 'REPLY'],
+        source: message.content.source,
+      };
+
+      if (responses && responses.length > 0) {
+        responses[0].content = errorContent;
+      }
+
+      if (callback) {
+        await callback(errorContent);
+      }
+
+      return true;
+    }
 
     try {
       console.log('🔧 Step 1: Getting Solana wallet...');
@@ -198,7 +223,9 @@ export const transferToSwigAction: Action = {
       console.error('🔧 Error stack:', error instanceof Error ? error.stack : 'No stack trace');
 
       const errorContent = {
-        text: `❌ Failed to transfer to Swig wallet: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        text: `❌ Failed to transfer to Swig wallet: ${
+          error instanceof Error ? error.message : 'Unknown error'
+        }`,
         thought:
           'The transfer to Swig wallet failed. This could be due to insufficient funds, network issues, or invalid parameters.',
         actions: ['TRANSFER_TO_SWIG', 'REPLY'],

--- a/packages/plugin/src/types.ts
+++ b/packages/plugin/src/types.ts
@@ -13,6 +13,10 @@ export interface SwigWalletConfig {
   commitment?: string;
 }
 
+export interface SwigPluginConfig {
+  transfersEnabled?: boolean;
+}
+
 export interface SwigAuthority {
   roleId: number;
   address: string;

--- a/packages/plugin/src/utils.ts
+++ b/packages/plugin/src/utils.ts
@@ -1,6 +1,6 @@
-import { Connection, Keypair, PublicKey, Transaction } from '@solana/web3.js';
+import { Connection, Keypair, Transaction } from '@solana/web3.js';
 import { IAgentRuntime, UUID } from '@elizaos/core';
-import { SolanaWalletProvider } from './types.js';
+import { SolanaWalletProvider, SwigPluginConfig } from './types.js';
 
 /**
  * Get Solana connection from runtime settings
@@ -94,4 +94,47 @@ export function formatSOL(lamports: number): string {
  */
 export function parseSOL(sol: string | number): number {
   return Math.round(Number(sol) * 1e9);
+}
+
+/**
+ * Get Swig plugin configuration from runtime settings
+ */
+export function getSwigConfig(runtime: IAgentRuntime): SwigPluginConfig {
+  const transfersEnabled = runtime.getSetting('SWIG_TRANSFERS_ENABLED');
+
+  return {
+    transfersEnabled: transfersEnabled === undefined ? true : String(transfersEnabled) === 'true',
+  };
+}
+
+/**
+ * Check if transfers are enabled in the configuration
+ */
+export function areTransfersEnabled(runtime: IAgentRuntime): boolean {
+  const config = getSwigConfig(runtime);
+  return config.transfersEnabled ?? true;
+}
+
+/**
+ * Validate if transfers are enabled and return error content if not
+ */
+export function validateTransfersEnabled(
+  runtime: IAgentRuntime,
+  actionName: string,
+  messageSource?: string
+) {
+  const transfersEnabledSetting = runtime.getSetting('SWIG_TRANSFERS_ENABLED');
+  const transfersEnabled =
+    transfersEnabledSetting === undefined ? true : String(transfersEnabledSetting) === 'true';
+
+  if (!transfersEnabled) {
+    return {
+      text: `❌ Transfer operations are currently disabled. Set SWIG_TRANSFERS_ENABLED=true to enable transfers.`,
+      thought: 'Transfer operations have been disabled in the plugin configuration.',
+      actions: [actionName, 'REPLY'],
+      source: messageSource,
+    };
+  }
+
+  return null; // No error, transfers enabled
 }


### PR DESCRIPTION
Add comprehensive configuration system to selectively enable/disable all transfer functionality in the Swig plugin while maintaining read-only capabilities.

Features:
- Add SwigPluginConfig interface for transfer control settings
- Add SWIG_TRANSFERS_ENABLED environment variable (default: true)
- Implement dynamic action loading in plugin initialization
- Add transfer validation utilities for runtime checks
- Update all transfer actions with configuration validation:
  - transferToSwig
  - transferTokenToSwig
  - swigTransferToAddress
  - swigTransferToAuthority
  - swigTransferTokenToAddress
  - swigTransferTokenToAuthority

Configuration:
- SWIG_TRANSFERS_ENABLED=false disables all transfer operations
- Read-only actions remain available (create wallets, check balances, view authorities)
- Backwards compatible (transfers enabled by default)
- Clear error messages guide users on re-enabling transfers

Documentation:
- Updated README with configuration examples
- Added environment variable documentation
- Included character settings examples

This enables secure deployment scenarios where agents should have access to Swig wallets without transfer capabilities.
